### PR TITLE
feat: cache datapackages per game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2271,7 @@ dependencies = [
  "bevy_embedded_assets",
  "bevy_ui_text_input",
  "crossbeam-channel",
+ "dirs",
  "float-ord",
  "futures",
  "rand 0.9.2",
@@ -3959,6 +3981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,6 +4382,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ bevy = { version = "0.17.3", features = ["bevy_picking"] }
 bevy_embedded_assets = "0.14.0"
 bevy_ui_text_input = "0.6.0"
 crossbeam-channel = "0.5.15"
+dirs = "6.0.0"
 float-ord = "0.3.2"
 futures = "0.3.31"
 rand = "0.9.2"

--- a/src/archipelago/datapackage.rs
+++ b/src/archipelago/datapackage.rs
@@ -1,0 +1,51 @@
+use std::{fs::File, io::Write};
+
+use serde::{Deserialize, Serialize};
+
+use crate::archipelago::MyDataPackage;
+
+use super::server_messages::DataPackageObject;
+
+#[derive(Deserialize, Serialize)]
+pub(super) struct DataPackageSave {
+    pub(super) game: String,
+    pub(super) datapackage: MyDataPackage,
+}
+
+pub(super) fn save_datapackage(game: &str, datapackage: &MyDataPackage) -> Result<(), ()> {
+    let Ok(datapackage_str) = serde_json::to_string(&DataPackageSave {
+        game: game.to_string(),
+        datapackage: datapackage.clone(),
+    }) else {
+        return Err(());
+    };
+
+    let Some(dir) = dirs::cache_dir() else {
+        return Err(());
+    };
+
+    let dir_path = dir.join("elementipelago").join("datapackages");
+
+    let file_path = dir_path.join(format!("{}.json", game));
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .create(dir_path)
+        .expect("could not create datapackage cache dir");
+
+    match File::create(&file_path) {
+        Ok(mut file) => file
+            .write_all(datapackage_str.as_bytes())
+            .expect("can not write to the file"),
+        Err(e) => {
+            eprintln!(
+                "could not create file at {}, due to error: {:?}",
+                file_path.to_str().unwrap(),
+                e
+            );
+            return Err(());
+        }
+    };
+
+    Ok(())
+}

--- a/src/archipelago/server_messages.rs
+++ b/src/archipelago/server_messages.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::shared_types::*;
 use bevy::platform::collections::HashMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_repr::Deserialize_repr;
 
 #[derive(Deserialize_repr, Debug)]
@@ -90,7 +90,7 @@ pub(super) enum NetworkSlot {
     } = 0b10,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub(super) struct DataPackageObject {
     pub(super) checksum: String,


### PR DESCRIPTION
create a file in `{cache_dir}/elementipelago/datapackages` for each game to cache the datapackage for that game. On game start load the cached packages in that folder and use the roominfo checksums to check if they're the correct version