### PR TITLE
fix: names when crafting with intermediates

### DIFF
--- a/src/lib/stores/apclient.svelte.js
+++ b/src/lib/stores/apclient.svelte.js
@@ -202,8 +202,7 @@ function extendReceivedElements(items) {
         }
         let elem_id = parse_element(item.name);
         receivedElements.add(item.name);
-        if (elementData.has(item.name)) {
-            console.log("skipping element since we already have", item.name);
+        if (elementData.has(item.name)) {            
             continue;
         }
 


### PR DESCRIPTION
When crafting a new intermediate it didn't use the correct name before. This PR fixes that